### PR TITLE
Upgraded to @prismicio/richtext 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
           marginLeft: 8,
           marginVertical: 8,
         },
-        oList: {
+        'o-list': {
           marginLeft: 8,
           marginVertical: 8,
         },
@@ -48,7 +48,7 @@
       // Optionally overwrite rendering with custom component
       serializers={{
         embed: (_type, element, _text, _children, _key) => {
-          const embed = (element as any) as OembedType
+          const embed = element as RTEmbedNode
           return <Text key={key}>{embed.oembed.title}</Text>
         },
       }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,8 @@
+import { RichTextField, RTNode } from '@prismicio/types'
 import React, { useEffect, useState } from 'react'
 import { RichText } from 'react-native-prismic-richtext'
-import { RichTextContent } from '../../typings'
 
-const fakeContent = [
+const fakeContent: RichTextField = [
   {
     type: 'paragraph',
     text:
@@ -34,11 +34,11 @@ const fakeContent = [
 ]
 
 const App = () => {
-  const [content, setContent] = useState<RichTextContent[]>(fakeContent)
+  const [content, setContent] = useState<RichTextField>(fakeContent)
   useEffect(() => {
     // fetch primsic richtext
     ;(async () => {
-      const fetchedContent: RichTextContent[] = fakeContent
+      const fetchedContent = fakeContent
       setContent(fetchedContent)
     })()
   }, [])
@@ -59,7 +59,7 @@ const App = () => {
           marginLeft: 8,
           marginVertical: 8,
         },
-        oList: {
+        'o-list': {
           marginLeft: 8,
           marginVertical: 8,
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-prismic-richtext",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "",
   "homepage": "https://github.com/Spoutnik97/react-native-prismic-richtext",
   "main": "lib/index.js",
@@ -55,6 +55,7 @@
     ]
   },
   "dependencies": {
-    "prismic-richtext": "^1.0.3"
+    "@prismicio/richtext": "^2.0.1",
+    "@prismicio/types": "^0.1.27"
   }
 }

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -1,3 +1,4 @@
+import { RTImageNode } from '@prismicio/types'
 import React from 'react'
 import {
   Image,
@@ -11,11 +12,11 @@ import {
   ViewStyle,
 } from 'react-native'
 
-import { ImageType, LinkFunction } from '../../typings'
+import { LinkFunction } from '../../typings'
 import { linkResolver } from '../services'
 
 type ImageProps = ViewProps & {
-  element: ImageType
+  element: RTImageNode
   wrapperStyle?: StyleProp<ViewStyle>
   style?: StyleProp<ImageStyle>
   onLinkPress?: LinkFunction
@@ -45,7 +46,7 @@ export const ImageView = (props: ImageProps) => {
         <Image
           style={[style, { width: width, height: height }]}
           source={{ uri: element.url }}
-          accessibilityLabel={element.alt}
+          accessibilityLabel={element.alt || ''}
         />
       </Pressable>
     </View>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-// @ts-ignore
-import PrismicRichText from 'prismic-richtext'
+import { serialize } from '@prismicio/richtext'
+import { RichTextField } from '@prismicio/types'
 import React, { createElement, Fragment } from 'react'
 
 import {
   LinkFunction,
-  RichTextContent,
   RichTextDefaultStyles,
   RichTextSerializer,
   RichTextStyles,
@@ -12,7 +11,7 @@ import {
 import { computeStyles, serializerWithStyle } from './services'
 
 type RichTextProps = {
-  richText: RichTextContent[]
+  richText: RichTextField
   defaultStyle?: RichTextDefaultStyles
   styles?: RichTextStyles
   ContainerComponent?: React.ComponentClass | React.ExoticComponent
@@ -41,7 +40,7 @@ export const RichText = ({
   }
 
   const computedStyles = computeStyles(defaultStyle, styles)
-  const serializedChildren = PrismicRichText.serialize(
+  const serializedChildren = serialize(
     richText,
     serializerWithStyle(computedStyles, onLinkPress, serializers)
   )

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,10 @@
-// @ts-ignore
-import { Elements } from 'prismic-richtext'
+import { RichTextFunctionSerializer } from '@prismicio/richtext'
+import {
+  FilledLinkToDocumentField,
+  FilledLinkToMediaField,
+  FilledLinkToWebField,
+  RichTextNodeType,
+} from '@prismicio/types'
 import {
   ImageStyle,
   StyleProp,
@@ -9,19 +14,12 @@ import {
   ViewStyle,
 } from 'react-native'
 
-export type RichTextElementType = Elements[keyof Elements]
+export type RichTextElementType = typeof RichTextNodeType[keyof typeof RichTextNodeType]
 
-export interface LinkType {
-  url: string
-  link_type: 'Web' | string
-  target?: string
-  type?: string
-  id?: string
-  uid?: string
-  slug?: string
-  lang?: string
-  isBroken?: boolean
-}
+export type LinkType =
+  | FilledLinkToDocumentField
+  | FilledLinkToWebField
+  | FilledLinkToMediaField
 
 export interface LinkFunction {
   (data: LinkType | undefined): void
@@ -31,49 +29,6 @@ type SpanDataType = {
   type: 'hyperlink'
   data?: LinkType
 }
-interface SpanType extends SpanDataType {
-  start: number
-  end: number
-  type: RichTextElementType
-}
-
-interface ImageType extends SpanDataType {
-  url: string
-  alt?: string
-  dimensions: {
-    width: number
-    height: number
-  }
-  type: RichTextElementType
-  linkTo: LinkType
-}
-
-export interface OembedType {
-  type: 'embed'
-  oembed: {
-    author_name?: string | null
-    author_url?: string | null
-    embed_url?: string | null
-    height?: number | null
-    html?: string | null
-    provider_name?: string | null
-    provider_url?: string | null
-    thumbnail_url?: string | null
-    thumbnail_height?: number | null
-    thumbnail_width?: number | null
-    title?: string | null
-    type?: string | null
-    version?: string | null
-    width?: number | null
-  }
-}
-
-export type RichTextContent = {
-  type: string
-  text: string
-  spans: SpanType[]
-}
-
 export type HTMLTags =
   | 'h1'
   | 'h2'
@@ -93,24 +48,29 @@ export type HTMLTags =
   | 'img'
 
 export type RichTextStyles = {
-  [key in keyof Elements]?:
+  [key in
+    | RichTextElementType
+    | 'imageWrapper'
+    | 'hyperlinkHover'
+    | 'list'
+    | 'o-list']?:
     | StyleProp<TextStyle>
     | StyleProp<ViewStyle>
     | StyleProp<ImageStyle>
 }
 
-export interface SerializerFunction {
-  (
-    type: RichTextElementType,
-    element: SpanType,
-    text: string,
-    children: React.ComponentElement<TextProps, Text>,
-    index: string
-  ): JSX.Element | null
-}
+export type SerializerFunction = RichTextFunctionSerializer<React.ComponentElement<
+  TextProps,
+  Text
+> | null>
+
+export type SerializerChildren = (React.ComponentElement<
+  TextProps,
+  Text
+> | null)[]
 
 export type RichTextSerializer = {
-  [key in keyof Elements]?: SerializerFunction
+  [key in RichTextElementType]?: SerializerFunction
 }
 
 export type RichTextDefaultStyles = TextStyle

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,18 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@prismicio/richtext@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@prismicio/richtext/-/richtext-2.0.1.tgz#6342f071601d88e99ca03faab382202087fd55a5"
+  integrity sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==
+  dependencies:
+    "@prismicio/types" "^0.1.22"
+
+"@prismicio/types@^0.1.22", "@prismicio/types@^0.1.27":
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/@prismicio/types/-/types-0.1.27.tgz#7f2fd91f1781a6da62630438b828230df72ae2b3"
+  integrity sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ==
+
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"
@@ -5561,14 +5573,6 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-prismic-richtext@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/prismic-richtext/-/prismic-richtext-1.0.3.tgz#ce8c8c18d65b01f1036f222b993ad2de700199fe"
-  integrity sha512-ZM45dVPL713+oDpt8ysWRY2pw3esBxRrqBlUO+q/T0WK0SNVSq29tQYhVdIALd8hRfF7X1lfpW0Q0YymEdh0AA==
-  dependencies:
-    ramda "^0.26.1"
-    uuid "^3.3.2"
-
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -5637,11 +5641,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-ramda@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.1:
   version "1.2.1"


### PR DESCRIPTION
This is a complete refactoring of the way this library is doing types
because the 2.0 of @prismicio has now typescript support. We now use
their type definitions where possible.

Closes #9 